### PR TITLE
Gnat-IO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ test
 doc
 cortex-gnat-rts*
 .DS_Store
+*~
 
 auto.cgpr
 gnatinspect.db
@@ -24,6 +25,7 @@ gpr_query.*
 
 local/
 examples/*/build/
+examples/*/sdkconfig
 
 demos-arduino-due/debounce_hardware
 demos-arduino-due/debounce_software

--- a/examples/gnatio/CMakeLists.txt
+++ b/examples/gnatio/CMakeLists.txt
@@ -1,0 +1,11 @@
+# For more information about build system see
+# https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/build-system.html
+# The following five lines of boilerplate have to be in your project's
+# CMakeLists in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.5)
+
+set(EXTRA_COMPONENT_DIRS "../..")
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(gnatio)
+

--- a/examples/gnatio/main/CMakeLists.txt
+++ b/examples/gnatio/main/CMakeLists.txt
@@ -1,0 +1,26 @@
+set(OBJ
+               ${COMPONENT_DIR}/.objs/b__gnatio.o
+               ${COMPONENT_DIR}/.objs/gnatio.o
+               ${COMPONENT_DIR}/.objs/g-io.o
+               )
+
+if(NOT CMAKE_BUILD_EARLY_EXPANSION)
+  # Compile Ada file and run binder
+  add_custom_command(OUTPUT ${OBJ}
+     COMMAND gprbuild -b -c -p -P ${COMPONENT_DIR}/gnatio.gpr
+               --RTS=${BUILD_DIR}/rts
+     DEPENDS gnatio.gpr gnatio.adb
+     VERBATIM)
+endif()
+
+idf_component_register(SRCS ".objs/b__gnatio.o"
+                            ".objs/gnatio.o"
+                            ".objs/g-io.o"
+                    INCLUDE_DIRS "."
+                    REQUIRES esp32-gnat-rts)
+
+# Required for s-fretcb.ads
+idf_build_set_property(COMPILE_DEFINITIONS -DconfigUSE_APPLICATION_TASK_TAG=1 APPEND)
+# Required for xTaskCreate in s-fretas.adb
+idf_build_set_property(COMPILE_DEFINITIONS -DconfigSUPPORT_DYNAMIC_ALLOCATION=1 APPEND)
+

--- a/examples/gnatio/main/g-io.adb
+++ b/examples/gnatio/main/g-io.adb
@@ -1,0 +1,137 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                         GNAT RUN-TIME COMPONENTS                         --
+--                                                                          --
+--                              G N A T . I O                               --
+--                                                                          --
+--                                 B o d y                                  --
+--                                                                          --
+--                     Copyright (C) 1995-2019, AdaCore                     --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --
+--                                                                          --
+-- GNAT was originally developed  by the GNAT team at  New York University. --
+-- Extensive contributions were provided by Ada Core Technologies Inc.      --
+--                                                                          --
+------------------------------------------------------------------------------
+
+--  This package body was taken from gcc-9.2 and adapted for the esp32
+--  runtime by Rolf Ebert. There is now stdout and stderr on a UART
+--  serial line.
+
+with System.Img_Int;
+
+package body GNAT.IO is
+
+   ---------
+   -- Get --
+   ---------
+
+   procedure Get (C : out Character) is
+      --  function Get_Char return Character;
+      --  pragma Import (C, Get_Char, "get_char");
+   begin
+      C := '@'; --  Get_Char;
+   end Get;
+
+   --------------
+   -- Get_Line --
+   --------------
+
+   procedure Get_Line (Item : out String; Last : out Natural) is
+      C : Character;
+
+   begin
+      for Nstore in Item'Range loop
+         Get (C);
+
+         if C = ASCII.LF then
+            Last := Nstore - 1;
+            return;
+
+         else
+            Item (Nstore) := C;
+         end if;
+      end loop;
+
+      Last := Item'Last;
+   end Get_Line;
+
+   --------------
+   -- New_Line --
+   --------------
+
+   procedure New_Line (Spacing : Positive := 1) is
+   begin
+      for J in 1 .. Spacing loop
+         Put (ASCII.LF);
+      end loop;
+   end New_Line;
+
+   ---------
+   -- Put --
+   ---------
+
+   procedure Put (X : Integer) is
+      use System.Img_Int;
+      Img : String (1 .. 11);
+      Pos : Natural := 0;
+   begin
+      Set_Image_Integer (X, Img, Pos);
+      Put (Img (1 .. Pos));
+   end Put;
+
+   --  procedure Put (File : File_Type; X : Integer) is
+   --     procedure Put_Int (X : Integer);
+   --     pragma Import (C, Put_Int, "put_int");
+
+   --     procedure Put_Int_Stderr (X : Integer);
+   --     pragma Import (C, Put_Int_Stderr, "put_int_stderr");
+
+   --  begin
+   --     case File is
+   --        when Stdout => Put_Int (X);
+   --        when Stderr => Put_Int_Stderr (X);
+   --     end case;
+   --  end Put;
+
+   procedure Put (C : Character) is
+      procedure Put_Char (C : Natural);
+      pragma Import (C, Put_Char, "putchar"); -- bind to standard C
+
+   begin
+      Put_Char (Character'Pos (C));
+   end Put;
+
+   procedure Put (S : String) is
+   begin
+      for C of S loop
+         Put (C);
+      end loop;
+   end Put;
+
+   --------------
+   -- Put_Line --
+   --------------
+
+   procedure Put_Line (S : String) is
+   begin
+      Put (S);
+      New_Line;
+   end Put_Line;
+
+end GNAT.IO;

--- a/examples/gnatio/main/g-io.ads
+++ b/examples/gnatio/main/g-io.ads
@@ -1,0 +1,69 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                         GNAT RUN-TIME COMPONENTS                         --
+--                                                                          --
+--                              G N A T . I O                               --
+--                                                                          --
+--                                 S p e c                                  --
+--                                                                          --
+--                     Copyright (C) 1995-2019, AdaCore                     --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --
+--                                                                          --
+-- GNAT was originally developed  by the GNAT team at  New York University. --
+-- Extensive contributions were provided by Ada Core Technologies Inc.      --
+--                                                                          --
+------------------------------------------------------------------------------
+
+--  A simple preelaborable subset of Text_IO capabilities
+
+--  A simple text I/O package that can be used for simple I/O functions in
+--  user programs as required. This package is also preelaborated, unlike
+--  Text_IO, and can thus be with'ed by preelaborated library units.
+
+--  Note that Data_Error is not raised by these subprograms for bad data.
+--  If such checks are needed then the regular Text_IO package must be used.
+
+--  This package spec was taken from gcc-9.2 for integration into the
+--  esp32 runtime. Currently output of integers and use Stndard_Error
+--  is commented out.
+
+package GNAT.IO is
+   pragma Preelaborate;
+
+   --  procedure Get (X : out Integer);
+   procedure Get (C : out Character);
+   procedure Get_Line (Item : out String; Last : out Natural);
+   --  These routines always read from Standard_Input
+
+   procedure Put (X : Integer);
+   --  Output integer, in contrast to standard Ada there is no leading
+   --  space before positive values.
+
+   procedure Put (C : Character);
+   --  Output character
+
+   procedure Put (S : String);
+   --  Output string
+
+   procedure Put_Line (S : String);
+   --  Output string followed by new line
+
+   procedure New_Line (Spacing : Positive := 1);
+   --  Output new line character
+
+end GNAT.IO;

--- a/examples/gnatio/main/gnatio.adb
+++ b/examples/gnatio/main/gnatio.adb
@@ -1,0 +1,57 @@
+--  SPDX-FileCopyrightText: 2021 Max Reznik <reznikmm@gmail.com>
+--
+--  SPDX-License-Identifier: MIT
+-------------------------------------------------------------
+
+with Gnat.IO;
+with Ada.Real_Time;
+
+procedure Gnatio
+  with No_Return
+is
+   use Gnat.IO;
+   use type Ada.Real_Time.Time_Span;
+
+   --  procedure puts
+   --    (data : System.Address)
+   --     with Import, Convention => C, External_Name => "puts";
+
+   Hello : String := "Hello from Ada!" & ASCII.NUL;
+begin
+   loop
+      Put ('c');
+      Put ('h');
+      Put ('a');
+      Put ('r');
+      Put ('s');
+      New_Line (2);
+
+      Put ("string");
+      New_Line (3);
+
+      for I in Integer'(0) .. 9 loop
+         Put (I); Put (' ');
+      end loop;
+      New_Line;
+
+      Fibb:
+      declare
+         Max : constant Natural := 1_000_000;
+         Val : Natural := 1;
+         Prev : Natural := 1;
+         Next : Natural := Val + Prev;
+      begin
+         while Val < Max loop
+            Put (Next); New_Line;
+            Prev := Val;
+            Val := Next;
+            Next := Prev + Val;
+         end loop;
+      end Fibb;
+
+      delay until Ada.Real_Time.Clock + Ada.Real_Time.Seconds (3);
+   end loop;
+
+  --  NOTE:
+  --  Make sure that main subprogram doen't return in a real project!
+end Gnatio;

--- a/examples/gnatio/main/gnatio.gpr
+++ b/examples/gnatio/main/gnatio.gpr
@@ -1,0 +1,10 @@
+--  SPDX-FileCopyrightText: 2021 Max Reznik <reznikmm@gmail.com>
+--
+--  SPDX-License-Identifier: MIT
+-------------------------------------------------------------
+
+project Gnatio is
+   for Target use "xtensa-esp32-elf";
+   for Main use ("gnatio.adb");
+   for Object_Dir use ".objs";
+end Gnatio;


### PR DESCRIPTION
Here is a pull request for a work in progress. Only output (no input) is provided via GNAT.IO

Unfortunately I have difficulties understanding the CMake build system. If I put g-io.ad? in either esp32/adainclude or esp32/esp32 the sample program compiles but the linker fails to find the object file g-io.o

Even in the examples directory I have to mention g-io.o explicitely twice in CMakeLists.txt. If not, the linker fails again. 